### PR TITLE
Set correct Content-Type header for sitemap.xml

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,8 @@
+/sitemap.xml
+  Content-Type: application/xml; charset=utf-8
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Permissions-Policy: interest-cohort=()

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,4 @@
 [[headers]]
-  for = "/sitemap.xml"
-  [headers.values]
-    Content-Type = "application/xml; charset=utf-8"
-    X-Frame-Options = "DENY"
-    X-XSS-Protection = "1; mode=block"
-    X-Content-Type-Options = "nosniff"
-    Permissions-Policy = "interest-cohort=()"
-
-[[headers]]
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   for = "/sitemap.xml"
   [headers.values]
     Content-Type = "application/xml; charset=utf-8"
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Permissions-Policy = "interest-cohort=()"
 
 [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,9 @@
 [[headers]]
+  for = "/sitemap.xml"
+  [headers.values]
+    Content-Type = "application/xml; charset=utf-8"
+
+[[headers]]
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"


### PR DESCRIPTION
## Summary
Added a specific header configuration for `sitemap.xml` to ensure it's served with the correct `application/xml` content type.

## Changes
- Added a new header rule in `netlify.toml` that targets `/sitemap.xml`
- Set the `Content-Type` header to `application/xml; charset=utf-8` for proper XML content type declaration
- This rule is placed before the catch-all `/*` rule to take precedence

## Details
This ensures that sitemap.xml files are served with the appropriate MIME type, which helps search engines and other tools correctly identify and parse the XML content.

https://claude.ai/code/session_01MXPKyUMSDcWPXEx81aUTJt